### PR TITLE
docs: Update template

### DIFF
--- a/Clean Swift/Interactor.xctemplate/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Interactor.xctemplate/___FILEBASENAME___Interactor.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 protocol ___VARIABLE_sceneName___BusinessLogic {
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request)
 }
@@ -9,17 +7,14 @@ protocol ___VARIABLE_sceneName___DataStore {
 }
 
 class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic, ___VARIABLE_sceneName___DataStore {
-  var presenter: ___VARIABLE_sceneName___PresentationLogic?
-  var worker: ___VARIABLE_sceneName___Worker?
-  //var name: String = ""
-  
-  // MARK: Do something
-  
+  var presenter: ___VARIABLE_sceneName___PresentationLogic = ___VARIABLE_sceneName___Presenter()
+  var worker: ___VARIABLE_sceneName___Worker = ___VARIABLE_sceneName___Worker()
+  //var name = ""
+
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
-    worker = ___VARIABLE_sceneName___Worker()
-    worker?.doSomeWork()
-    
+    worker.doSomeWork()
+
     let response = ___VARIABLE_sceneName___.Something.Response()
-    presenter?.presentSomething(response: response)
+    presenter.presentSomething(response: response)
   }
 }

--- a/Clean Swift/Models.xctemplate/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Models.xctemplate/___FILEBASENAME___Models.swift
@@ -1,8 +1,4 @@
-import UIKit
-
 enum ___VARIABLE_sceneName___ {
-  // MARK: Use cases
-  
   enum Something {
     struct Request {
     }

--- a/Clean Swift/Presenter.xctemplate/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Presenter.xctemplate/___FILEBASENAME___Presenter.swift
@@ -6,9 +6,7 @@ protocol ___VARIABLE_sceneName___PresentationLogic {
 
 class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLogic {
   weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
-  
-  // MARK: Do something
-  
+
   func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
     let viewModel = ___VARIABLE_sceneName___.Something.ViewModel()
     viewController?.displaySomething(viewModel: viewModel)

--- a/Clean Swift/Router.xctemplate/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Router.xctemplate/___FILEBASENAME___Router.swift
@@ -1,41 +1,35 @@
 import UIKit
 
-@objc protocol ___VARIABLE_sceneName___RoutingLogic {
-  //func routeToSomewhere(segue: UIStoryboardSegue?)
+protocol ___VARIABLE_sceneName___RoutingLogic {
+  //func routeToSomewhere()
 }
 
 protocol ___VARIABLE_sceneName___DataPassing {
   var dataStore: ___VARIABLE_sceneName___DataStore? { get }
 }
 
-class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
+class ___VARIABLE_sceneName___Router: ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
   weak var viewController: ___VARIABLE_sceneName___ViewController?
   var dataStore: ___VARIABLE_sceneName___DataStore?
-  
+
   // MARK: Routing
-  
-  //func routeToSomewhere(segue: UIStoryboardSegue?) {
-  //  if let segue = segue {
-  //    let destinationVC = segue.destination as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //  } else {
-  //    let storyboard = UIStoryboard(name: "Main", bundle: nil)
-  //    let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //    navigateToSomewhere(source: viewController!, destination: destinationVC)
-  //  }
+
+  //func routeToSomewhere() {
+  //  let storyboard = UIStoryboard(name: "Main", bundle: nil)
+  //  let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
+  //  var destinationDS = destinationVC.router!.dataStore!
+  //  passDataToSomewhere(source: dataStore!, destination: &destinationDS)
+  //  navigateToSomewhere(source: viewController!, destination: destinationVC)
   //}
 
   // MARK: Navigation
-  
+
   //func navigateToSomewhere(source: ___VARIABLE_sceneName___ViewController, destination: SomewhereViewController) {
   //  source.show(destination, sender: nil)
   //}
-  
+
   // MARK: Passing data
-  
+
   //func passDataToSomewhere(source: ___VARIABLE_sceneName___DataStore, destination: inout SomewhereDataStore) {
   //  destination.name = source.name
   //}

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Interactor.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 protocol ___VARIABLE_sceneName___BusinessLogic {
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request)
 }
@@ -9,17 +7,14 @@ protocol ___VARIABLE_sceneName___DataStore {
 }
 
 class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic, ___VARIABLE_sceneName___DataStore {
-  var presenter: ___VARIABLE_sceneName___PresentationLogic?
-  var worker: ___VARIABLE_sceneName___Worker?
-  //var name: String = ""
-  
-  // MARK: Do something
-  
+  var presenter: ___VARIABLE_sceneName___PresentationLogic = ___VARIABLE_sceneName___Presenter()
+  var worker: ___VARIABLE_sceneName___Worker = ___VARIABLE_sceneName___Worker()
+  //var name = ""
+
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
-    worker = ___VARIABLE_sceneName___Worker()
-    worker?.doSomeWork()
-    
+    worker.doSomeWork()
+
     let response = ___VARIABLE_sceneName___.Something.Response()
-    presenter?.presentSomething(response: response)
+    presenter.presentSomething(response: response)
   }
 }

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Models.swift
@@ -1,8 +1,6 @@
-import UIKit
-
 enum ___VARIABLE_sceneName___ {
   // MARK: Use cases
-  
+
   enum Something {
     struct Request {
     }

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Presenter.swift
@@ -6,9 +6,7 @@ protocol ___VARIABLE_sceneName___PresentationLogic {
 
 class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLogic {
   weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
-  
-  // MARK: Do something
-  
+
   func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
     let viewModel = ___VARIABLE_sceneName___.Something.ViewModel()
     viewController?.displaySomething(viewModel: viewModel)

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Router.swift
@@ -1,41 +1,35 @@
 import UIKit
 
-@objc protocol ___VARIABLE_sceneName___RoutingLogic {
-  //func routeToSomewhere(segue: UIStoryboardSegue?)
+protocol ___VARIABLE_sceneName___RoutingLogic {
+  //func routeToSomewhere()
 }
 
 protocol ___VARIABLE_sceneName___DataPassing {
   var dataStore: ___VARIABLE_sceneName___DataStore? { get }
 }
 
-class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
+class ___VARIABLE_sceneName___Router: ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
   weak var viewController: ___VARIABLE_sceneName___ViewController?
   var dataStore: ___VARIABLE_sceneName___DataStore?
-  
+
   // MARK: Routing
-  
-  //func routeToSomewhere(segue: UIStoryboardSegue?) {
-  //  if let segue = segue {
-  //    let destinationVC = segue.destination as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //  } else {
-  //    let storyboard = UIStoryboard(name: "Main", bundle: nil)
-  //    let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //    navigateToSomewhere(source: viewController!, destination: destinationVC)
-  //  }
+
+  //func routeToSomewhere() {
+  //  let storyboard = UIStoryboard(name: "Main", bundle: nil)
+  //  let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
+  //  var destinationDS = destinationVC.router!.dataStore!
+  //  passDataToSomewhere(source: dataStore!, destination: &destinationDS)
+  //  navigateToSomewhere(source: viewController!, destination: destinationVC)
   //}
 
   // MARK: Navigation
-  
+
   //func navigateToSomewhere(source: ___VARIABLE_sceneName___ViewController, destination: SomewhereViewController) {
   //  source.show(destination, sender: nil)
   //}
-  
+
   // MARK: Passing data
-  
+
   //func passDataToSomewhere(source: ___VARIABLE_sceneName___DataStore, destination: inout SomewhereDataStore) {
   //  destination.name = source.name
   //}

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UICollectionViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Scene.xctemplate/UICollectionViewController/___FILEBASENAME___Worker.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 class ___VARIABLE_sceneName___Worker {
   func doSomeWork() {
   }

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Interactor.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 protocol ___VARIABLE_sceneName___BusinessLogic {
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request)
 }
@@ -9,17 +7,14 @@ protocol ___VARIABLE_sceneName___DataStore {
 }
 
 class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic, ___VARIABLE_sceneName___DataStore {
-  var presenter: ___VARIABLE_sceneName___PresentationLogic?
-  var worker: ___VARIABLE_sceneName___Worker?
-  //var name: String = ""
-  
-  // MARK: Do something
-  
+  var presenter: ___VARIABLE_sceneName___PresentationLogic = ___VARIABLE_sceneName___Presenter()
+  var worker: ___VARIABLE_sceneName___Worker = ___VARIABLE_sceneName___Worker()
+  //var name = ""
+
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
-    worker = ___VARIABLE_sceneName___Worker()
-    worker?.doSomeWork()
-    
+    worker.doSomeWork()
+
     let response = ___VARIABLE_sceneName___.Something.Response()
-    presenter?.presentSomething(response: response)
+    presenter.presentSomething(response: response)
   }
 }

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Models.swift
@@ -1,8 +1,6 @@
-import UIKit
-
 enum ___VARIABLE_sceneName___ {
   // MARK: Use cases
-  
+
   enum Something {
     struct Request {
     }

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Presenter.swift
@@ -6,9 +6,7 @@ protocol ___VARIABLE_sceneName___PresentationLogic {
 
 class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLogic {
   weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
-  
-  // MARK: Do something
-  
+
   func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
     let viewModel = ___VARIABLE_sceneName___.Something.ViewModel()
     viewController?.displaySomething(viewModel: viewModel)

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Router.swift
@@ -1,41 +1,35 @@
 import UIKit
 
-@objc protocol ___VARIABLE_sceneName___RoutingLogic {
-  //func routeToSomewhere(segue: UIStoryboardSegue?)
+protocol ___VARIABLE_sceneName___RoutingLogic {
+  //func routeToSomewhere()
 }
 
 protocol ___VARIABLE_sceneName___DataPassing {
   var dataStore: ___VARIABLE_sceneName___DataStore? { get }
 }
 
-class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
+class ___VARIABLE_sceneName___Router: ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
   weak var viewController: ___VARIABLE_sceneName___ViewController?
   var dataStore: ___VARIABLE_sceneName___DataStore?
-  
+
   // MARK: Routing
-  
-  //func routeToSomewhere(segue: UIStoryboardSegue?) {
-  //  if let segue = segue {
-  //    let destinationVC = segue.destination as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //  } else {
-  //    let storyboard = UIStoryboard(name: "Main", bundle: nil)
-  //    let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //    navigateToSomewhere(source: viewController!, destination: destinationVC)
-  //  }
+
+  //func routeToSomewhere() {
+  //  let storyboard = UIStoryboard(name: "Main", bundle: nil)
+  //  let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
+  //  var destinationDS = destinationVC.router!.dataStore!
+  //  passDataToSomewhere(source: dataStore!, destination: &destinationDS)
+  //  navigateToSomewhere(source: viewController!, destination: destinationVC)
   //}
 
   // MARK: Navigation
-  
+
   //func navigateToSomewhere(source: ___VARIABLE_sceneName___ViewController, destination: SomewhereViewController) {
   //  source.show(destination, sender: nil)
   //}
-  
+
   // MARK: Passing data
-  
+
   //func passDataToSomewhere(source: ___VARIABLE_sceneName___DataStore, destination: inout SomewhereDataStore) {
   //  destination.name = source.name
   //}

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UITableViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Scene.xctemplate/UITableViewController/___FILEBASENAME___Worker.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 class ___VARIABLE_sceneName___Worker {
   func doSomeWork() {
   }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 protocol ___VARIABLE_sceneName___BusinessLogic {
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request)
 }
@@ -9,17 +7,14 @@ protocol ___VARIABLE_sceneName___DataStore {
 }
 
 class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic, ___VARIABLE_sceneName___DataStore {
-  var presenter: ___VARIABLE_sceneName___PresentationLogic?
-  var worker: ___VARIABLE_sceneName___Worker?
-  //var name: String = ""
-  
-  // MARK: Do something
-  
+  var presenter: ___VARIABLE_sceneName___PresentationLogic = ___VARIABLE_sceneName___Presenter()
+  var worker: ___VARIABLE_sceneName___Worker = ___VARIABLE_sceneName___Worker()
+  //var name = ""
+
   func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
-    worker = ___VARIABLE_sceneName___Worker()
-    worker?.doSomeWork()
-    
+    worker.doSomeWork()
+
     let response = ___VARIABLE_sceneName___.Something.Response()
-    presenter?.presentSomething(response: response)
+    presenter.presentSomething(response: response)
   }
 }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
@@ -1,8 +1,6 @@
-import UIKit
-
 enum ___VARIABLE_sceneName___ {
   // MARK: Use cases
-  
+
   enum Something {
     struct Request {
     }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Presenter.swift
@@ -6,9 +6,7 @@ protocol ___VARIABLE_sceneName___PresentationLogic {
 
 class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLogic {
   weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
-  
-  // MARK: Do something
-  
+
   func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
     let viewModel = ___VARIABLE_sceneName___.Something.ViewModel()
     viewController?.displaySomething(viewModel: viewModel)

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Router.swift
@@ -1,41 +1,35 @@
 import UIKit
 
-@objc protocol ___VARIABLE_sceneName___RoutingLogic {
-  //func routeToSomewhere(segue: UIStoryboardSegue?)
+protocol ___VARIABLE_sceneName___RoutingLogic {
+  //func routeToSomewhere()
 }
 
 protocol ___VARIABLE_sceneName___DataPassing {
   var dataStore: ___VARIABLE_sceneName___DataStore? { get }
 }
 
-class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
+class ___VARIABLE_sceneName___Router: ___VARIABLE_sceneName___RoutingLogic, ___VARIABLE_sceneName___DataPassing {
   weak var viewController: ___VARIABLE_sceneName___ViewController?
   var dataStore: ___VARIABLE_sceneName___DataStore?
-  
+
   // MARK: Routing
-  
-  //func routeToSomewhere(segue: UIStoryboardSegue?) {
-  //  if let segue = segue {
-  //    let destinationVC = segue.destination as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //  } else {
-  //    let storyboard = UIStoryboard(name: "Main", bundle: nil)
-  //    let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
-  //    var destinationDS = destinationVC.router!.dataStore!
-  //    passDataToSomewhere(source: dataStore!, destination: &destinationDS)
-  //    navigateToSomewhere(source: viewController!, destination: destinationVC)
-  //  }
+
+  //func routeToSomewhere() {
+  //  let storyboard = UIStoryboard(name: "Main", bundle: nil)
+  //  let destinationVC = storyboard.instantiateViewController(withIdentifier: "SomewhereViewController") as! SomewhereViewController
+  //  var destinationDS = destinationVC.router!.dataStore!
+  //  passDataToSomewhere(source: dataStore!, destination: &destinationDS)
+  //  navigateToSomewhere(source: viewController!, destination: destinationVC)
   //}
 
   // MARK: Navigation
-  
+
   //func navigateToSomewhere(source: ___VARIABLE_sceneName___ViewController, destination: SomewhereViewController) {
   //  source.show(destination, sender: nil)
   //}
-  
+
   // MARK: Passing data
-  
+
   //func passDataToSomewhere(source: ___VARIABLE_sceneName___DataStore, destination: inout SomewhereDataStore) {
   //  destination.name = source.name
   //}

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Worker.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 class ___VARIABLE_sceneName___Worker {
   func doSomeWork() {
   }

--- a/Clean Swift/Unit Tests.xctemplate/TemplateInfo.plist
+++ b/Clean Swift/Unit Tests.xctemplate/TemplateInfo.plist
@@ -46,6 +46,20 @@
 			<key>Type</key>
 			<string>static</string>
     </dict>
+	<dict>
+			<key>Default</key>
+			<string>___VARIABLE_sceneName:identifier___BusinessLogicSpy</string>
+			<key>Description</key>
+			<string>The business logic spy name</string>
+			<key>Identifier</key>
+			<string>businessLogicSpyName</string>
+			<key>Name</key>
+			<string>Business Logic Spy Name:</string>
+			<key>Required</key>
+			<true/>
+			<key>Type</key>
+			<string>static</string>
+    </dict>
     <dict>
 			<key>Default</key>
 			<string>___VARIABLE_sceneName:identifier___InteractorTests</string>
@@ -62,6 +76,20 @@
     </dict>
     <dict>
 			<key>Default</key>
+			<string>___VARIABLE_sceneName:identifier___PresentationLogicSpy</string>
+			<key>Description</key>
+			<string>The presentation logic spy tests name</string>
+			<key>Identifier</key>
+			<string>presentationLogicSpyName</string>
+			<key>Name</key>
+			<string>Presentation Logic Spy Name:</string>
+			<key>Required</key>
+			<true/>
+			<key>Type</key>
+			<string>static</string>
+    </dict>
+    <dict>
+			<key>Default</key>
 			<string>___VARIABLE_sceneName:identifier___PresenterTests</string>
 			<key>Description</key>
 			<string>The presenter tests name</string>
@@ -69,6 +97,34 @@
 			<string>presenterTestsName</string>
 			<key>Name</key>
 			<string>Presenter Tests Name:</string>
+			<key>Required</key>
+			<true/>
+			<key>Type</key>
+			<string>static</string>
+    </dict>
+    <dict>
+			<key>Default</key>
+			<string>___VARIABLE_sceneName:identifier___DisplayLogicSpy</string>
+			<key>Description</key>
+			<string>The display logic spy tests name</string>
+			<key>Identifier</key>
+			<string>displayLogicSpyName</string>
+			<key>Name</key>
+			<string>Display Logic Spy Name:</string>
+			<key>Required</key>
+			<true/>
+			<key>Type</key>
+			<string>static</string>
+    </dict>
+    <dict>
+			<key>Default</key>
+			<string>___VARIABLE_sceneName:identifier___BusinessLogicSpy</string>
+			<key>Description</key>
+			<string>The business logic spy name</string>
+			<key>Identifier</key>
+			<string>businessLogicSpyName</string>
+			<key>Name</key>
+			<string>Business Logic Spy Name:</string>
 			<key>Required</key>
 			<true/>
 			<key>Type</key>

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___BusinessLogicSpy.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___BusinessLogicSpy.swift
@@ -1,0 +1,8 @@
+@testable import ___PROJECTNAMEASIDENTIFIER___
+
+class ___VARIABLE_sceneName___BusinessLogicSpy: ___VARIABLE_sceneName___BusinessLogic {
+  var actionCalled = false
+  func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
+    actionCalled = true
+  }
+}

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___DisplayLogicSpy.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___DisplayLogicSpy.swift
@@ -1,0 +1,9 @@
+@testable import ___PROJECTNAMEASIDENTIFIER___
+
+class ___VARIABLE_sceneName___DisplayLogicSpy: ___VARIABLE_sceneName___DisplayLogic {
+  var displaySomethingCalled = false
+
+  func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
+    displaySomethingCalled = true
+  }
+}

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___InteractorTests.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___InteractorTests.swift
@@ -2,49 +2,20 @@
 import XCTest
 
 class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
-  // MARK: Subject under test
-  
   var sut: ___VARIABLE_sceneName___Interactor!
-  
-  // MARK: Test lifecycle
-  
+
   override func setUp() {
     super.setUp()
-    setup___VARIABLE_sceneName___Interactor()
-  }
-  
-  override func tearDown() {
-    super.tearDown()
-  }
-  
-  // MARK: Test setup
-  
-  func setup___VARIABLE_sceneName___Interactor() {
     sut = ___VARIABLE_sceneName___Interactor()
   }
-  
-  // MARK: Test doubles
-  
-  class ___VARIABLE_sceneName___PresentationLogicSpy: ___VARIABLE_sceneName___PresentationLogic {
-    var presentSomethingCalled = false
-    
-    func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
-      presentSomethingCalled = true
-    }
-  }
-  
-  // MARK: Tests
-  
-  func testDoSomething() {
-    // Given
+
+  func testdoSomething() {
     let spy = ___VARIABLE_sceneName___PresentationLogicSpy()
     sut.presenter = spy
     let request = ___VARIABLE_sceneName___.Something.Request()
-    
-    // When
+
     sut.doSomething(request: request)
-    
-    // Then
+
     XCTAssertTrue(spy.presentSomethingCalled, "doSomething(request:) should ask the presenter to format the result")
   }
 }

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___PresentationLogicSpy.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___PresentationLogicSpy.swift
@@ -1,0 +1,9 @@
+@testable import ___PROJECTNAMEASIDENTIFIER___
+
+class ___VARIABLE_sceneName___PresentationLogicSpy: ___VARIABLE_sceneName___PresentationLogic {
+  var presentSomethingCalled = false
+
+  func presentSomething(response: ___VARIABLE_sceneName___.Something.Response) {
+    presentSomethingCalled = true
+  }
+}

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___PresenterTests.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___PresenterTests.swift
@@ -2,49 +2,20 @@
 import XCTest
 
 class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
-  // MARK: Subject under test
-  
   var sut: ___VARIABLE_sceneName___Presenter!
-  
-  // MARK: Test lifecycle
-  
+
   override func setUp() {
     super.setUp()
-    setup___VARIABLE_sceneName___Presenter()
-  }
-  
-  override func tearDown() {
-    super.tearDown()
-  }
-  
-  // MARK: Test setup
-  
-  func setup___VARIABLE_sceneName___Presenter() {
     sut = ___VARIABLE_sceneName___Presenter()
   }
-  
-  // MARK: Test doubles
-  
-  class ___VARIABLE_sceneName___DisplayLogicSpy: ___VARIABLE_sceneName___DisplayLogic {
-    var displaySomethingCalled = false
-    
-    func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
-      displaySomethingCalled = true
-    }
-  }
-  
-  // MARK: Tests
-  
+
   func testPresentSomething() {
-    // Given
     let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
     sut.viewController = spy
     let response = ___VARIABLE_sceneName___.Something.Response()
-    
-    // When
+
     sut.presentSomething(response: response)
-    
-    // Then
+
     XCTAssertTrue(spy.displaySomethingCalled, "presentSomething(response:) should ask the view controller to display the result")
   }
 }

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___ViewControllerTests.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___ViewControllerTests.swift
@@ -2,70 +2,31 @@
 import XCTest
 
 class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
-  // MARK: Subject under test
-  
   var sut: ___VARIABLE_sceneName___ViewController!
-  var window: UIWindow!
-  
-  // MARK: Test lifecycle
-  
+
   override func setUp() {
     super.setUp()
-    window = UIWindow()
-    setup___VARIABLE_sceneName___ViewController()
-  }
-  
-  override func tearDown() {
-    window = nil
-    super.tearDown()
-  }
-  
-  // MARK: Test setup
-  
-  func setup___VARIABLE_sceneName___ViewController() {
-    let bundle = Bundle.main
-    let storyboard = UIStoryboard(name: "Main", bundle: bundle)
+    let storyboard = UIStoryboard(name: "Main", bundle: .main)
     sut = storyboard.instantiateViewController(withIdentifier: "___VARIABLE_sceneName___ViewController") as! ___VARIABLE_sceneName___ViewController
   }
-  
-  func loadView() {
-    window.addSubview(sut.view)
-    RunLoop.current.run(until: Date())
-  }
-  
-  // MARK: Test doubles
-  
-  class ___VARIABLE_sceneName___BusinessLogicSpy: ___VARIABLE_sceneName___BusinessLogic {
-    var doSomethingCalled = false
-    
-    func doSomething(request: ___VARIABLE_sceneName___.Something.Request) {
-      doSomethingCalled = true
-    }
-  }
-  
-  // MARK: Tests
-  
-  func testShouldDoSomethingWhenViewIsLoaded() {
-    // Given
+
+  func testShouldactionWhenViewIsLoaded() {
     let spy = ___VARIABLE_sceneName___BusinessLogicSpy()
     sut.interactor = spy
-    
-    // When
-    loadView()
-    
-    // Then
-    XCTAssertTrue(spy.doSomethingCalled, "viewDidLoad() should ask the interactor to do something")
+
+    _ = sut.view
+    sut.viewDidLoad()
+
+    XCTAssertTrue(spy.actionCalled, "viewDidLoad() should ask the interactor to do something")
   }
-  
+
   func testDisplaySomething() {
-    // Given
     let viewModel = ___VARIABLE_sceneName___.Something.ViewModel()
-    
-    // When
-    loadView()
+
+    _ = sut.view
+    sut.viewDidLoad()
     sut.displaySomething(viewModel: viewModel)
-    
-    // Then
+
     //XCTAssertEqual(sut.nameTextField.text, "", "displaySomething(viewModel:) should update the name text field")
   }
 }

--- a/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___WorkerTests.swift
+++ b/Clean Swift/Unit Tests.xctemplate/___FILEBASENAME___WorkerTests.swift
@@ -2,36 +2,14 @@
 import XCTest
 
 class ___VARIABLE_sceneName___WorkerTests: XCTestCase {
-  // MARK: Subject under test
-  
   var sut: ___VARIABLE_sceneName___Worker!
-  
-  // MARK: Test lifecycle
-  
+
   override func setUp() {
     super.setUp()
-    setup___VARIABLE_sceneName___Worker()
-  }
-  
-  override func tearDown() {
-    super.tearDown()
-  }
-  
-  // MARK: Test setup
-  
-  func setup___VARIABLE_sceneName___Worker() {
     sut = ___VARIABLE_sceneName___Worker()
   }
-  
-  // MARK: Test doubles
-  
-  // MARK: Tests
-  
-  func testSomething() {
-    // Given
-    
-    // When
-    
-    // Then
+
+  func test_doSomeWork() {
+    sut.doSomeWork()
   }
 }

--- a/Clean Swift/View Controller.xctemplate/UICollectionViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/View Controller.xctemplate/UICollectionViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UICollectionViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/View Controller.xctemplate/UITableViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/View Controller.xctemplate/UITableViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UITableViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/View Controller.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/View Controller.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
@@ -5,63 +5,40 @@ protocol ___VARIABLE_sceneName___DisplayLogic: class {
 }
 
 class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_sceneName___DisplayLogic {
-  var interactor: ___VARIABLE_sceneName___BusinessLogic?
-  var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
+  //@IBOutlet weak var nameTextField: UITextField!
 
-  // MARK: Object lifecycle
-  
+  var interactor: ___VARIABLE_sceneName___BusinessLogic = ___VARIABLE_sceneName___Interactor()
+  var router: (___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing) = ___VARIABLE_sceneName___Router()
+
+  // MARK: - Setup
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     setup()
   }
-  
+
   required init?(coder aDecoder: NSCoder) {
     super.init(coder: aDecoder)
     setup()
   }
-  
-  // MARK: Setup
-  
+
   private func setup() {
-    let viewController = self
-    let interactor = ___VARIABLE_sceneName___Interactor()
-    let presenter = ___VARIABLE_sceneName___Presenter()
-    let router = ___VARIABLE_sceneName___Router()
-    viewController.interactor = interactor
-    viewController.router = router
-    interactor.presenter = presenter
-    presenter.viewController = viewController
-    router.viewController = viewController
+    interactor.presenter.viewController = self
+    router.viewController = self
     router.dataStore = interactor
   }
-  
-  // MARK: Routing
-  
-  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-    if let scene = segue.identifier {
-      let selector = NSSelectorFromString("routeTo\(scene)WithSegue:")
-      if let router = router, router.responds(to: selector) {
-        router.perform(selector, with: segue)
-      }
-    }
-  }
-  
-  // MARK: View lifecycle
-  
+
+  // MARK: - View lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
     doSomething()
   }
-  
-  // MARK: Do something
-  
-  //@IBOutlet weak var nameTextField: UITextField!
-  
+
+  // MARK: - Actions
   func doSomething() {
     let request = ___VARIABLE_sceneName___.Something.Request()
-    interactor?.doSomething(request: request)
+    interactor.doSomething(request: request)
   }
-  
+
   func displaySomething(viewModel: ___VARIABLE_sceneName___.Something.ViewModel) {
     //nameTextField.text = viewModel.name
   }

--- a/Clean Swift/Worker.xctemplate/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Worker.xctemplate/___FILEBASENAME___Worker.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 class ___VARIABLE_sceneName___Worker {
   func doSomeWork() {
   }


### PR DESCRIPTION
- Reduce setup steps. By always initial at variables
- Remove optional when it no need
- Remove `import UIKit` from worker, it should not use
- Remove `import UIKit` from the view model, it may not use
- Remove `MARK: Use cases` from the view model
- Remove router part from view controller. We do not prefer to use segue
- `MARK: Do something` to `MARK: - Actions`
- Remove `MARK: Do something` in the presenter
- `MARK: Setup` to `MARK: - Setup` and move to the above view controller constructor. It should not belong in the constructor function
- Move `IBOutlet` above everything, we are following the below order.
  1. Interface
  1. Outlets
  1. Local variables
  1. Initializations
  1. Object lift cycles
  1. Actions
- Remove white space in empty line
- Remove `tearDown()` from tests
- Remove `UIWindow` from tests, just call `_ = sut.view` is faster like a thousand times in unit testing. Except we want to working on some UI interaction.
- Remove NSObjectProtocol, @objc, NSObject, since it no use with Objective-C and Segue
- Separate presentation logic spy to file
- Separate business logic spy to file
- Separate display logic spy to file

If the change did not list here, I am sorry. Feel free to comment below.